### PR TITLE
リストの更新をrealm-android-adapterに任せる

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'io.realm:android-adapters:3.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/src/main/java/dev/touyou/checkitoutandroid/ui/main/ControlFragment.kt
+++ b/app/src/main/java/dev/touyou/checkitoutandroid/ui/main/ControlFragment.kt
@@ -55,19 +55,17 @@ class ControlFragment : Fragment() {
         })
 
         val realm = Realm.getDefaultInstance()
-        var soundList = realm.where(SoundData::class.java).findAll().toMutableList()
+        var soundList = realm.where(SoundData::class.java).findAll()
         viewModel.getSoundData().observe(viewLifecycleOwner, Observer {
-            soundList = it.toMutableList()
             println("update realm data: $soundList")
-            viewModel.changeSoundAll(soundList)
-            adapter.notifyDataSetChanged()
+            viewModel.changeSoundAll(soundList.toMutableList())
         })
-        adapter = SoundViewAdapter(soundList)
+        adapter = SoundViewAdapter(soundList, true)
         adapter.setOnItemClickListener(object : SoundViewAdapter.onItemClickListener {
             override fun onClick(view: View, position: Int) {
                 viewModel.selectedPad?.let {
                     if (mode == PlayMode.EDIT) {
-                        viewModel.changeSound(it, soundList[position])
+                        viewModel.changeSound(it, soundList[position]!!)
                         viewModel.selectedPad = null
                         adapter.notifyItemChanged(position)
                     }

--- a/app/src/main/java/dev/touyou/checkitoutandroid/ui/main/SoundViewAdapter.kt
+++ b/app/src/main/java/dev/touyou/checkitoutandroid/ui/main/SoundViewAdapter.kt
@@ -9,9 +9,14 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import dev.touyou.checkitoutandroid.R
 import dev.touyou.checkitoutandroid.entity.SoundData
+import io.realm.OrderedRealmCollection
+import io.realm.RealmRecyclerViewAdapter
 
-class SoundViewAdapter(private val soundList: List<SoundData>) :
-    RecyclerView.Adapter<SoundViewAdapter.SoundViewHolder>() {
+class SoundViewAdapter(
+    private val soundList: OrderedRealmCollection<SoundData>?,
+    private val autoUpdate: Boolean
+) :
+    RealmRecyclerViewAdapter<SoundData, SoundViewAdapter.SoundViewHolder>(soundList, autoUpdate) {
     private var listener: onItemClickListener? = null
 
     class SoundViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -31,13 +36,14 @@ class SoundViewAdapter(private val soundList: List<SoundData>) :
             )
         )
 
-    override fun getItemCount(): Int = soundList.size
+    override fun getItemCount(): Int = soundList?.size ?: 0
 
     @SuppressLint("SetTextI18n")
     override fun onBindViewHolder(holder: SoundViewHolder, position: Int) {
-        holder.soundNameTextView.text = soundList[position].displayName
+        val soundData = soundList?.get(position) ?: return
+        holder.soundNameTextView.text = soundData.displayName
         holder.padTextView.text =
-            if (soundList[position].padNum == -1) "NONE" else "PAD ${soundList[position].padNum + 1}"
+            if (soundData.padNum == -1) "NONE" else "PAD ${soundData.padNum + 1}"
         holder.baseLayout.setOnClickListener {
             listener?.onClick(it, position)
         }


### PR DESCRIPTION
realm-android-adapters(https://github.com/realm/realm-android-adapters) を使ってみるパターン

Realm公式が出しているAdapterのライブラリで、これを使うとRealmのDB内が書き換わったときに自動でViewを更新してくれる

ちなみに内部実装を読んでみると、RealmResultsを渡したときにAdapter内でChangeListenerを作ってくれていて、内容が変わったところだけ更新してくれるのでパフォーマンスも良い。

内部実装: https://github.com/realm/realm-android-adapters/blob/master/adapters/src/main/java/io/realm/RealmRecyclerViewAdapter.java#L52


